### PR TITLE
Replace golint with revive.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ test:
 	go test -cover ./...
 
 lint:
-	golangci-lint run -E gofmt -E golint --exclude-use-default=false
+	golangci-lint run -E gofmt -E revive --exclude-use-default=false
 
 image:
 	$(eval IMAGE=$(shell ko publish --local . 2>/dev/null))


### PR DESCRIPTION
golint is no longer maintained. golangci-lint recommends
https://github.com/mgechev/revive as a drop-in replacement.

Corrects a warning building with recent golangci-lint.