### PR TITLE
Run executable as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o ia2 ./
 FROM scratch
 COPY --from=builder /src/ia2 /
 EXPOSE 8080
+# Switch to the UID that's typically reserved for the user "nobody".
+USER 65534
+
 CMD ["/ia2"]

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ var (
 )
 
 func main() {
+	l.Printf("Running as UID %d.", os.Getuid())
 	enclave := nitriding.NewEnclave(
 		&nitriding.Config{
 			SOCKSProxy: fmt.Sprintf("socks5://%s", localProxy),


### PR DESCRIPTION
One should avoid running executables as root in Docker.  This patch
creates a non-privileged user called ia2-user and switches to it before
running the program.